### PR TITLE
Uses systemd-resolved to resolve the client names

### DIFF
--- a/dib/elements/centos-8-k2hdkc/post-install.d/98-k2hdkc
+++ b/dib/elements/centos-8-k2hdkc/post-install.d/98-k2hdkc
@@ -5,7 +5,12 @@ set -o xtrace
 
 # Replace /etc/resolv.conf.ORIG with new resolver
 if test -f "/etc/resolv.conf.ORIG"; then
-    echo > /etc/resolv.conf.ORIG
+    cat > /etc/resolv.conf.ORIG << EOF
+nameserver 127.0.0.53
+options edns0
+search openstacklocal
+EOF
+
 else
     echo "/etc/resolv.conf.ORIG not found"
 fi


### PR DESCRIPTION
## Relevant Issue (if applicable)
N/A

## Details
This PR changes resolv.conf in the guest image to resolve internal IPs and hosts by using systemd-resolved.