### PR TITLE
Changes the usage_timeout two times longer

### DIFF
--- a/devstack/patches/etc-trove-trove.conf
+++ b/devstack/patches/etc-trove-trove.conf
@@ -20,6 +20,22 @@
 *** /etc/trove/trove.conf	2020-05-14 01:35:21.189626000 +0000
 --- trove.conf	2020-05-14 08:27:24.575853312 +0000
 ***************
+*** 7,13 ****
+  control_exchange = trove
+  rpc_backend = rabbit
+  reboot_time_out = 300
+! usage_timeout = 900
+  agent_call_high_timeout = 1200
+  use_syslog = False
+  debug = True
+--- 15,21 ----
+  control_exchange = trove
+  rpc_backend = rabbit
+  reboot_time_out = 300
+! usage_timeout = 1800
+  agent_call_high_timeout = 1200
+  use_syslog = False
+  debug = True
 *** 55,60 ****
 --- 55,63 ----
   [db2]


### PR DESCRIPTION
## Relevant Issue (if applicable)
N/A

## Details
This PR make usage_timeout two times longer(15min -> 30min).
* It takes about 20 minutes to create a database instance in Azure and GCP(The spec of Host VM is 4vCPU and 16GB ram).
  * After GuestAgent sends an Active notification to MQ, TaskManager defaultly sets the instance status ERROR when the instance doesn't send the notification within 15 minutes.
  * This PR makes TaskManager to wait for 30 minutes to set the instance status ERROR.

