### PR TITLE
Corresponds to CentOS-8.3.2011

### DIFF
--- a/utils/custom_devstack_patch_stack.sh
+++ b/utils/custom_devstack_patch_stack.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+cd ~/devstack
+cat > ./patch-stack-sh.txt << EOF
+diff --git a/stack.sh b/stack.sh
+index 036afd7b..ddefb1db 100755
+--- a/stack.sh
++++ b/stack.sh
+@@ -352,9 +352,9 @@ if [[ $DISTRO == "rhel8" ]]; then
+         sudo dnf config-manager --set-enabled epel
+     fi
+
+-    # PowerTools repo provides libyaml-devel required by devstack itself and
+-    # EPEL packages assume that the PowerTools repository is enable.
+-    sudo dnf config-manager --set-enabled PowerTools
++    # powertools repo provides libyaml-devel required by devstack itself and
++    # EPEL packages assume that the powertools repository is enable.
++    sudo dnf config-manager --set-enabled powertools
+
+     if [[ ${SKIP_EPEL_INSTALL} != True ]]; then
+         _install_epel
+EOF
+
+patch ./stack.sh < ./patch-stack-sh.txt
+

--- a/utils/custom_devstack_setup_2.sh
+++ b/utils/custom_devstack_setup_2.sh
@@ -63,6 +63,12 @@ if test "${OS_NAME}" = "centos"; then
     sudo dnf install -y git
     git clone https://git.openstack.org/openstack-dev/devstack --branch ${DEVSTACK_BRANCH} ${DEVSTACK_DIR}
 
+    # patch stack.sh
+    grep "^CentOS Linux release 8.3" /etc/centos-release
+    if test $? -eq 0; then
+        sh ${SRCDIR}/custom_devstack_patch_stack.sh
+    fi
+
     # Uses the custom git repository
     sh ${SRCDIR}/custom_devstack_local.conf.sh
 
@@ -86,6 +92,17 @@ if test "${OS_NAME}" = "centos"; then
 
     # semanage is required
     sudo dnf install -y policycoreutils-python-utils
+
+    # python3-systemd for centos-8.3 and centos-8.2
+    grep "^CentOS Linux release 8" /etc/centos-release
+    if test $? -eq 0; then
+        sudo dnf install -y python3-systemd
+    fi
+    # libusbx libvirt qemu-kvm for centos-8.2
+    grep "^CentOS Linux release 8.2" /etc/centos-release
+    if test $? -eq 0; then
+        sudo dnf install -y  libusbx libvirt qemu-kvm
+    fi
 
     # Deactivates libvirt default network eternally
     sudo virsh net-destroy default


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Added support for CentOS-8.3.2011
#### Rename PowerTools repository
- The names of the yum package repositories that devstack refers to when installing libyaml-devel are unified in lowercase.
- https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2011#Yum_repo_file_and_repoid_changes
#### Avoid systemd-python compilation errors
- A compile error occurs when installing systemd-python.
- As a workaround, install the binary package before devstack installs the pip package systemd-python.
### Added support for CentOS-8.2
- Fixed an issue with libusbx and libvirt dependencies
- systemd-python changed to install binary package instead of pip package
