### PR TITLE
Fixed to set the project name of example_resource.txt variable

### DIFF
--- a/devstack/patches/trove_dashboard-api-trove.py
+++ b/devstack/patches/trove_dashboard-api-trove.py
@@ -18,10 +18,10 @@
 #
 
 diff --git a/trove_dashboard/api/trove.py b/trove_dashboard/api/trove.py
-index 83208de..2201a92 100644
+index 83208de..3b3266c 100644
 --- a/trove_dashboard/api/trove.py
 +++ b/trove_dashboard/api/trove.py
-@@ -25,6 +25,16 @@
+@@ -25,6 +25,16 @@ from keystoneauth1 import loading
  from keystoneauth1 import session
  from novaclient import client as nova_client
 
@@ -38,7 +38,7 @@ index 83208de..2201a92 100644
  # Supported compute versions
  NOVA_VERSIONS = base.APIVersionManager("compute", preferred_version=2)
  NOVA_VERSIONS.load_supported_version(1.1,
-@@ -67,7 +77,8 @@
+@@ -67,7 +77,8 @@ def cluster_delete(request, cluster_id):
 
  def cluster_create(request, name, volume, flavor, num_instances,
                     datastore, datastore_version,
@@ -48,7 +48,7 @@ index 83208de..2201a92 100644
      instances = []
      for i in range(num_instances):
          instance = {}
-@@ -84,7 +95,8 @@
+@@ -84,7 +95,8 @@ def cluster_create(request, name, volume, flavor, num_instances,
          datastore,
          datastore_version,
          instances=instances,
@@ -58,7 +58,7 @@ index 83208de..2201a92 100644
 
 
  def cluster_grow(request, cluster_id, new_instances):
-@@ -414,8 +426,210 @@
+@@ -414,8 +426,214 @@ def configuration_instances(request, group_id):
      return troveclient(request).configurations.instances(group_id)
 
 
@@ -159,6 +159,7 @@ index 83208de..2201a92 100644
 +        http.POST(k2hr3_token)
 +        k2hr3_resource = K2hr3Resource(
 +            k2hr3_token.token,
++            project=request.user.project_name,
 +            name=values["cluster-name"],
 +            data_type='string',
 +            data=Path('/opt/stack/k2hdkc_dbaas/utils/python-k2hr3client/examples/example_resource.txt'),
@@ -173,6 +174,7 @@ index 83208de..2201a92 100644
 +        http.POST(k2hr3_resource)
 +        k2hr3_resource_server = K2hr3Resource(
 +            k2hr3_token.token,
++            project=request.user.project_name,
 +            name="/".join([values["cluster-name"],"server"]),
 +            data_type='string',
 +            data="",
@@ -187,6 +189,7 @@ index 83208de..2201a92 100644
 +        http.POST(k2hr3_resource_server)
 +        k2hr3_resource_slave = K2hr3Resource(
 +            k2hr3_token.token,
++            project=request.user.project_name,
 +            name="/".join([values["cluster-name"],"slave"]),
 +            data_type='string',
 +            data="",
@@ -194,7 +197,8 @@ index 83208de..2201a92 100644
 +                "chmpx-mode": "SLAVE",
 +                "k2hr3-init-packages": "",
 +                "k2hr3-init-packagecloud-packages": "k2hdkc-dbaas-override-conf, k2hr3-get-resource, chmpx",
-+                "k2hr3-init-systemd-packages": "chmpx.service, k2hr3-get-resource.timer"
++                "k2hr3-init-systemd-packages": "chmpx.service, k2hr3-get-resource.timer",
++                "k2hdkc-dbaas-add-user": 1
 +            },
 +            alias=[]
 +        )
@@ -270,4 +274,3 @@ index 83208de..2201a92 100644
 
 
  def configuration_default(request, instance_id):
-

--- a/utils/python-k2hr3client/examples/example_resource.txt
+++ b/utils/python-k2hr3client/examples/example_resource.txt
@@ -68,8 +68,8 @@ K2HMAXELE           = 16
 #
 # SERVER NODES SECTION
 #
-{{ foreach %host_key% in %yrn:yahoo:::demo:role:__TROVE_K2HDKC_CLUSTER_NAME__/server/hosts/ip% }}
-    {{ %one_host% = %yrn:yahoo:::demo:role:__TROVE_K2HDKC_CLUSTER_NAME__/server/hosts/ip%{%host_key%} }}
+{{ foreach %host_key% in %yrn:yahoo:::__TROVE_K2HDKC_TENANT_NAME__:role:__TROVE_K2HDKC_CLUSTER_NAME__/server/hosts/ip% }}
+    {{ %one_host% = %yrn:yahoo:::__TROVE_K2HDKC_TENANT_NAME__:role:__TROVE_K2HDKC_CLUSTER_NAME__/server/hosts/ip%{%host_key%} }}
 [SVRNODE]
 NAME                = {{= %one_host%{'host'} }}
 CUK                 = {{= %one_host%{'cuk'} }}
@@ -82,9 +82,9 @@ SSL                 = no
 #
 # SLAVE NODES SECTION
 #
-{{ if 0 < %yrn:yahoo:::demo:role:__TROVE_K2HDKC_CLUSTER_NAME__/slave/hosts/ip%.length }}
-    {{ foreach %host_key% in %yrn:yahoo:::demo:role:__TROVE_K2HDKC_CLUSTER_NAME__/slave/hosts/ip% }}
-        {{ %one_host% = %yrn:yahoo:::demo:role:__TROVE_K2HDKC_CLUSTER_NAME__/slave/hosts/ip%{%host_key%} }}
+{{ if 0 < %yrn:yahoo:::__TROVE_K2HDKC_TENANT_NAME__:role:__TROVE_K2HDKC_CLUSTER_NAME__/slave/hosts/ip%.length }}
+    {{ foreach %host_key% in %yrn:yahoo:::__TROVE_K2HDKC_TENANT_NAME__:role:__TROVE_K2HDKC_CLUSTER_NAME__/slave/hosts/ip% }}
+        {{ %one_host% = %yrn:yahoo:::__TROVE_K2HDKC_TENANT_NAME__:role:__TROVE_K2HDKC_CLUSTER_NAME__/slave/hosts/ip%{%host_key%} }}
 [SLVNODE]
 NAME                = {{= %one_host%{'host'} }}
 CUK                 = {{= %one_host%{'cuk'} }}

--- a/utils/python-k2hr3client/examples/resource_api.py
+++ b/utils/python-k2hr3client/examples/resource_api.py
@@ -55,6 +55,7 @@ if __name__ == '__main__':
     # 2. Makes a new k2hr3 resource
     k2hr3_resource = K2hr3Resource(
         k2hr3_token.token,
+        project=args.project,
         name=args.resource,
         data_type='string',
         data=Path('./example_resource.txt'),

--- a/utils/python-k2hr3client/k2hr3client/resource.py
+++ b/utils/python-k2hr3client/k2hr3client/resource.py
@@ -46,14 +46,15 @@ class K2hr3Resource(K2hr3Api):  # pylint: disable=too-many-instance-attributes
     """Represents K2hr3 RESOURCE API. See https://k2hr3.antpick.ax/api_resource.html for details.
     """
 
-    __slots__ = ('_r3token', '_name', '_data_type', '_data', '_keys', '_alias')
+    __slots__ = ('_r3token', '_project', '_name', '_data_type', '_data', '_keys', '_alias')
 
-    def __init__(self, r3token, name, data_type, data, keys, alias=None):  # pylint: disable=too-many-arguments
+    def __init__(self, r3token, project, name, data_type, data, keys, alias=None):  # pylint: disable=too-many-arguments
         super().__init__("resource")
         self.r3token = r3token
+        self.project = project
         self.name = name
         self.data_type = data_type
-        self.set_data(data, name)
+        self.set_data(data, project, name)
         self.keys = keys
         self.alias = alias
         # NOTE(hiwakaba)
@@ -116,7 +117,7 @@ class K2hr3Resource(K2hr3Api):  # pylint: disable=too-many-instance-attributes
         """ Returns data."""
         return self._data
 
-    def set_data(self, val, clustername):  # type: ignore # noqa: F811
+    def set_data(self, val, projectname, clustername):  # type: ignore # noqa: F811
         """ Sets data."""
         if getattr(self, '_data', None) is None:
             self._data = val
@@ -134,6 +135,8 @@ class K2hr3Resource(K2hr3Api):  # pylint: disable=too-many-instance-attributes
                 for line in iter(f.readline, ''):
                     # 3. replace TROVE_K2HDKC_CLUSTER_NAME with clustername
                     line = re.sub('__TROVE_K2HDKC_CLUSTER_NAME__', clustername, line)
+                    # 4. replace TROVE_K2HDKC_TENANT_NAME with projectname
+                    line = re.sub('__TROVE_K2HDKC_TENANT_NAME__', projectname, line)
                     line_len += len(line)
                     if line_len > _MAX_LINE_LENGTH:
                         raise Exception('data too big')

--- a/utils/python-k2hr3client/tests/test_policy.py
+++ b/utils/python-k2hr3client/tests/test_policy.py
@@ -29,8 +29,8 @@ from k2hr3client.policy import K2hr3Policy
 LOG = logging.getLogger(__name__)
 
 
-class TestK2hr3Resource(unittest.TestCase):
-    """Tests the K2hr3Response class.
+class TestK2hr3Policy(unittest.TestCase):
+    """Tests the K2hr3Policy class.
 
     Simple usage(this class only):
     $ python -m unittest tests/test_resource.py
@@ -53,7 +53,7 @@ class TestK2hr3Resource(unittest.TestCase):
         """Tears down a test case."""
 
     def test_k2hr3resource_construct(self):
-        """Creates a K2hr3Response  instance."""
+        """Creates a K2hr3Policy  instance."""
         k2hr3_policy = K2hr3Policy(self.token,
                                    name=self.name,
                                    effect=self.effect,
@@ -64,7 +64,7 @@ class TestK2hr3Resource(unittest.TestCase):
         self.assertIsInstance(k2hr3_policy, K2hr3Policy)
 
     def test_k2hr3resource_repr(self):
-        """Represent a K2hr3Response instance."""
+        """Represent a K2hr3Policy instance."""
         k2hr3_policy = K2hr3Policy(self.token,
                                    name=self.name,
                                    effect=self.effect,

--- a/utils/python-k2hr3client/tests/test_resource.py
+++ b/utils/python-k2hr3client/tests/test_resource.py
@@ -41,6 +41,7 @@ class TestK2hr3Resource(unittest.TestCase):
     def setUp(self):
         """Sets up a test case."""
         self.name = "test_resource"
+        self.project = "test_project"
         self.data_type = 'string'
         self.data = "testresourcedata"
         self.keys = {
@@ -56,13 +57,13 @@ class TestK2hr3Resource(unittest.TestCase):
 
     def test_k2hr3resource_construct(self):
         """Creates a K2hr3Resoiurce  instance."""
-        resource = K2hr3Resource("k2hr3tokenvalue", self.name, self.data_type,
+        resource = K2hr3Resource("k2hr3tokenvalue", self.project, self.name, self.data_type,
                                  self.data, self.keys, self.alias)
         self.assertIsInstance(resource, K2hr3Resource)
 
     def test_k2hr3resource_repr(self):
         """Represent a K2hr3Resource instance."""
-        resource = K2hr3Resource("k2hr3tokenvalue", self.name, self.data_type,
+        resource = K2hr3Resource("k2hr3tokenvalue", self.project, self.name, self.data_type,
                                  self.data, self.keys, self.alias)
         # Note: The order of _error and _code is unknown!
         self.assertRegex(repr(resource), '<K2hr3Resource .*>')


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
The following corrections have been made.
### Make the project name variable with resource data
The project name (tenant name) defined in example_resource.txt was fixed (demo), so I changed it to be variable.
Along with this, some files have been modified.
### test_policy.py
The class name for the test was typo (TestK2hr3Resource), so I fixed it (TestK2hr3Policy).