### PR TITLE
[gh-pages] Updated gh-pages for release k2hdkc dbaas trove v1.0.6

### DIFF
--- a/whatnew.md
+++ b/whatnew.md
@@ -14,6 +14,10 @@ next_string: Usage
 ---
 
 # What's new
+## [5 Jun 2025] K2HDKC DBaaS with Trove Release Version 1.0.6
+K2HDKC DBaaS with Trove Release Version(1.0.6), all source code released on Github.com.  
+This version corresponds to OpenStack Trove `stable/2025.1`.
+
 ## [19 Mar 2025] K2HDKC DBaaS with Trove Release Version 1.0.4
 K2HDKC DBaaS with Trove Release Version(1.0.4), all source code released on Github.com.  
 This version corresponds to OpenStack Trove `stable/2024.2`.

--- a/whatnewja.md
+++ b/whatnewja.md
@@ -14,6 +14,10 @@ next_string: Usage
 ---
 
 # What's new
+## 2025年6月5日
+K2HDKC DBaaS with Trove Version 1.0.6 のソースコードをGithub.comで公開しました。  
+このバージョンは、OpenStack Trove の `stable/2025.1`に対応します。
+
 ## 2025年3月19日
 K2HDKC DBaaS with Trove Version 1.0.4 のソースコードをGithub.comで公開しました。  
 このバージョンは、OpenStack Trove の `stable/2024.2`に対応します。


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
The What's New page has been updated with the release of K2HDKC DBaaS Trove v1.0.6.
